### PR TITLE
refactor: axios Exception Pipe

### DIFF
--- a/src/circuit-breaker-manager.ts
+++ b/src/circuit-breaker-manager.ts
@@ -15,7 +15,7 @@ export class Circuit {
 
     state: CircuitBreakerState = CircuitBreakerState.Closed;
 
-    public static exceptionPipes: Array<(e: Error) => Error> = [AxiosExceptionPipe, TypeormExceptionPipe];
+    public static exceptionPipes: Array<(e: unknown) => unknown> = [AxiosExceptionPipe, TypeormExceptionPipe];
 
     constructor(caller: string, funcName: string, options: CircuitBreakerOptions) {
         this.id = (++seq).toString();

--- a/src/exceptions/axios-extended-error.ts
+++ b/src/exceptions/axios-extended-error.ts
@@ -1,96 +1,24 @@
-// dummy
-class AxiosErrorLike<T = unknown, D = any> extends Error {
-    config!: any;
-    code?: string;
-    request?: any;
-    response?: any;
-    isAxiosError!: boolean;
-    status?: string;
-    constructor(message?: string, code?: string, config?: any, request?: any, response?: any) {
-        super();
-    }
-}
+import { HttpStatus } from '@nestjs/common';
+import { ErrorHttpStatusCode, HttpErrorByCode } from '@nestjs/common/utils/http-error-by-code.util';
+import axios from 'axios';
 
-let axiosErrorLike = AxiosErrorLike;
-let nestjsErrorConvert = (e: AxiosErrorLike) => e;
-
-export declare class RequestUriTooLongException {}
-export declare class TooManyRequestException {}
-
-try {
-    const axios = require('axios');
-    const nestjs = require('@nestjs/common');
-
-    if (axios?.AxiosError) axiosErrorLike = axios.AxiosError;
-
-    class RequestUriTooLongException extends nestjs.HttpException {
-        constructor(objectOrError?: string | object | any, description?: string) {
-            super(nestjs.HttpException.createBody(objectOrError, description, 414), 414);
-        }
-    }
-
-    class TooManyRequestException extends nestjs.HttpException {
-        constructor(objectOrError?: string | object | any, description?: string) {
-            super(nestjs.HttpException.createBody(objectOrError, description, 429), 429);
-        }
-    }
-
-    nestjsErrorConvert = (e: AxiosErrorLike) => {
-        switch (e.status || e.response?.status?.toString()) {
-            case '400':
-                return new nestjs.BadRequestException(e);
-            case '401':
-                return new nestjs.UnauthorizedException(e);
-            case '403':
-                return new nestjs.ForbiddenException(e);
-            case '404':
-                return new nestjs.NotFoundException(e);
-            case '405':
-                return new nestjs.MethodNotAllowedException(e);
-            case '406':
-                return new nestjs.NotAcceptableException(e);
-            case '408':
-                return new nestjs.RequestTimeoutException(e);
-            case '409':
-                return new nestjs.ConflictException(e);
-            case '410':
-                return new nestjs.GoneException(e);
-            case '412':
-                return new nestjs.PreconditionFailedException(e);
-            case '413':
-                return new nestjs.PayloadTooLargeException(e);
-            case '414':
-                return new RequestUriTooLongException(e);
-            case '415':
-                return new nestjs.UnsupportedMediaTypeException(e);
-            case '418':
-                return new nestjs.ImATeapotException(e);
-            case '422':
-                return new nestjs.UnprocessableEntityException(e);
-            case '429':
-                return new TooManyRequestException(e);
-            case '500':
-                return new nestjs.InternalServerErrorException(e);
-            case '501':
-                return new nestjs.NotImplementedException(e);
-            case '502':
-                return new nestjs.BadGatewayException(e);
-            case '503':
-                return new nestjs.ServiceUnavailableException(e);
-            case '504':
-                return new nestjs.GatewayTimeoutException(e);
-            case '505':
-                return new nestjs.HttpVersionNotSupportedException(e);
-        }
-
-        if (e.code === 'ECONNABORTED' && e.message?.match(/timeout/i)) return new nestjs.RequestTimeoutException(e);
+export const AxiosExceptionPipe = (e: unknown) => {
+    if (!axios.isAxiosError(e)) {
         return e;
-    };
-} catch (e) {}
+    }
 
-export const AxiosExceptionPipe = (e: Error): Error => {
-    if (!(e instanceof axiosErrorLike)) return e;
-    const error: AxiosErrorLike = e;
+    const axiosErrorStatus: ErrorHttpStatusCode = ((): number => {
+        if (e.code === 'ECONNABORTED' && e.message?.match(/timeout/i)) {
+            return HttpStatus.REQUEST_TIMEOUT;
+        }
+        if (e.response?.status) {
+            return e.response?.status;
+        }
+        if (e.status) {
+            +e.status;
+        }
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    })();
 
-    return nestjsErrorConvert(error);
+    return new HttpErrorByCode[axiosErrorStatus](e.message);
 };

--- a/src/exceptions/typeorm-extended-error.ts
+++ b/src/exceptions/typeorm-extended-error.ts
@@ -18,8 +18,10 @@ try {
 export class TypeormConnectionFailedError extends TypeormQueryFailedError {}
 export class TypeormQueryTimeoutError extends TypeormQueryFailedError {}
 
-export const TypeormExceptionPipe = (e: Error): Error => {
-    if (!(e instanceof TypeormQueryFailedError)) return e;
+export const TypeormExceptionPipe = (e: unknown): unknown => {
+    if (!(e instanceof TypeormQueryFailedError)) {
+        return e;
+    }
     const error: TypeormQueryFailedErrorLike = e;
 
     const driverError: string = (error as any).driverError?.toString();

--- a/src/test/axios-extended-error.spec.ts
+++ b/src/test/axios-extended-error.spec.ts
@@ -7,21 +7,21 @@ describe('AxiosExtendedError', () => {
         try {
             await Axios.get('https://httpstat.us/404');
         } catch (e) {
-            expect(AxiosExceptionPipe(e as Error).constructor).toBe(NotFoundException);
+            expect(AxiosExceptionPipe(e)).toBeInstanceOf(NotFoundException);
         }
     });
     it('502 error', async () => {
         try {
             await Axios.get('https://httpstat.us/502');
         } catch (e) {
-            expect(AxiosExceptionPipe(e as Error).constructor).toBe(BadGatewayException);
+            expect(AxiosExceptionPipe(e)).toBeInstanceOf(BadGatewayException);
         }
     });
     it('Timeout error', async () => {
         try {
             await Axios.get('https://httpstat.us/200?sleep=3000', { timeout: 1000 });
         } catch (e) {
-            expect(AxiosExceptionPipe(e as Error).constructor).toBe(RequestTimeoutException);
+            expect(AxiosExceptionPipe(e)).toBeInstanceOf(RequestTimeoutException);
         }
     });
 });

--- a/src/test/typeorm-extended-error.spec.ts
+++ b/src/test/typeorm-extended-error.spec.ts
@@ -5,8 +5,12 @@ import { ObjectUtils } from 'typeorm/util/ObjectUtils';
 describe('TypeormExtendedError', () => {
     it('Normal? error', async () => {
         const error = TypeormExceptionPipe(new Error('Normal? error'));
-        expect(error.constructor).toBe(Error);
-        expect(error.message).toBe('Normal? error');
+        expect(error).toBeInstanceOf(Error);
+        if (error instanceof Error) {
+            expect(error.message).toBe('Normal? error');
+        } else {
+            throw new Error('cannot occur');
+        }
     });
 
     it('Normal? QueryFailedError', async () => {
@@ -22,7 +26,7 @@ describe('TypeormExtendedError', () => {
             routine: 'parserOpenTable',
         });
         const error = TypeormExceptionPipe(new QueryFailedError(`SELECT * FROM NOT_EXISTS_TABLE`, undefined, driverError));
-        expect(error.constructor).toBe(QueryFailedError);
+        expect(error).toBeInstanceOf(QueryFailedError);
         expect(error instanceof QueryFailedError).toBeTruthy();
     });
 
@@ -38,7 +42,7 @@ describe('TypeormExtendedError', () => {
             routine: 'ProcessInterrupts',
         });
         const error = TypeormExceptionPipe(new QueryFailedError(`SELECT pg_sleep(10)`, undefined, driverError));
-        expect(error.constructor).toBe(TypeormConnectionFailedError);
+        expect(error).toBeInstanceOf(TypeormConnectionFailedError);
         expect(error instanceof TypeormConnectionFailedError).toBeTruthy();
         expect(error instanceof QueryFailedError).toBeTruthy();
     });
@@ -46,7 +50,7 @@ describe('TypeormExtendedError', () => {
     it('Timeout error', async () => {
         const driverError = new Error('Query read timeout');
         const error = TypeormExceptionPipe(new QueryFailedError(`SELECT pg_sleep(10)`, undefined, driverError));
-        expect(error.constructor).toBe(TypeormQueryTimeoutError);
+        expect(error).toBeInstanceOf(TypeormQueryTimeoutError);
         expect(error instanceof TypeormQueryTimeoutError).toBeTruthy();
         expect(error instanceof QueryFailedError).toBeTruthy();
     });


### PR DESCRIPTION
Refactoring the AxiosExceptionPipe.

### Goal
- No longer have to manage `each Http status code`.

### Description
- Convert to NestJs`s HttpError for http Status using nestJs common util.
- The type defined as Error has been changed to Unknown
 ( https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables )

------
AxiosExceptionPipe 코드를 refactoring 합니다.

### 목적
- 각각의 Http Status Code를 관리하지 않아도 됩니다.

### 설명
- nestJs common util을 이용하여 변환하도록 합니다.
- Error로 정의된 type을 Unknown으로 변경하였습니다. 
 ( https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables )