### PR TITLE
chore: release v1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-circuit-breaker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-circuit-breaker",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/common": "^11.1.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-circuit-breaker",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Circuit Breaker: Decorators and tools that can easily apply the Circuit Breaker pattern.",
   "homepage": "https://github.com/kibae/node-circuit-breaker",
   "repository": {


### PR DESCRIPTION
## v1.0.3

### Security
- fix: bump tar >=7.5.3 (CVE-2026-23745 외 5건)
- fix: bump @tootallnate/once >=3.0.1 (CVE-2026-3449)

> Merging this PR will trigger the npm publish workflow.