### PR TITLE
Add Node.js 26 support (v1.1.0)

### DIFF
--- a/.github/workflows/nodejs26.yml
+++ b/.github/workflows/nodejs26.yml
@@ -1,0 +1,49 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js(26) CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [26]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - name: Info
+      run: |
+        echo "Node version: $(node -v)"
+        echo "NPM version: $(npm -v)"
+        echo "NPM cache: $(npm config get cache)"
+    - run: npm ci
+    - run: npm run build
+    - run: cp dist/circuit-breaker-worker.js src/
+    - run: npm test
+    - uses: phoenix-actions/test-reporting@v8
+      if: success() || failure()
+      id: test-report
+      with:
+        name: JEST Tests (${{ matrix.node-version }})
+        path: junit.xml
+        reporter: jest-junit
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Node.js(20) CI](https://github.com/kibae/node-circuit-breaker/actions/workflows/nodejs20.yml/badge.svg)](https://github.com/kibae/node-circuit-breaker/actions/workflows/nodejs20.yml)
 [![Node.js(22) CI](https://github.com/kibae/node-circuit-breaker/actions/workflows/nodejs22.yml/badge.svg)](https://github.com/kibae/node-circuit-breaker/actions/workflows/nodejs22.yml)
 [![Node.js(24) CI](https://github.com/kibae/node-circuit-breaker/actions/workflows/nodejs24.yml/badge.svg)](https://github.com/kibae/node-circuit-breaker/actions/workflows/nodejs24.yml)
+[![Node.js(26) CI](https://github.com/kibae/node-circuit-breaker/actions/workflows/nodejs26.yml/badge.svg)](https://github.com/kibae/node-circuit-breaker/actions/workflows/nodejs26.yml)
 
 ## Install
 - NPM

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-circuit-breaker",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Circuit Breaker: Decorators and tools that can easily apply the Circuit Breaker pattern.",
   "homepage": "https://github.com/kibae/node-circuit-breaker",
   "repository": {


### PR DESCRIPTION
## Summary
- Add Node.js 26 CI workflow (`.github/workflows/nodejs26.yml`)
- Add Node.js 26 CI badge to README
- Bump version 1.0.2 -> 1.1.0 (minor)

## Release
- This PR has the `release` label, so once merged into main the `npm-publish.yml` workflow will automatically run `npm publish`, create the git tag (`v1.1.0`), and open a draft GitHub Release.

## Test
- `npm run build` + `npm test` pass locally (10 tests passed)