### PR TITLE
Use npm Trusted Publishing (OIDC) for npm release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,9 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     environment: github action
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -20,6 +23,9 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm (Trusted Publishing requires npm >= 11.5.1)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -41,8 +47,6 @@ jobs:
 
       - name: Publish to NPM
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create tag
         run: |
@@ -52,13 +56,3 @@ jobs:
           git push origin "v${{ steps.package_version.outputs.version }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: "v${{ steps.package_version.outputs.version }}"
-          release_name: "v${{ steps.package_version.outputs.version }}"
-          draft: true
-          prerelease: false


### PR DESCRIPTION
## Summary
Switch the npm release workflow from a long-lived `NPM_TOKEN` to npm **Trusted Publishing** (OIDC).

## Changes
- Add `id-token: write` permission so GitHub Actions can mint an OIDC token (and `contents: write` for tag push)
- Add a step to upgrade npm to `>= 11.5.1`, which is required for Trusted Publishing (Node 20 ships npm 10.x)
- Remove `NODE_AUTH_TOKEN` / `NPM_TOKEN` from the publish step
- Remove the leftover automated draft GitHub Release step (this removal was intended in #22 but did not land on `main`)

## Required manual setup (npmjs.com)
Before this can publish, configure a Trusted Publisher on the `node-circuit-breaker` package:
- Publisher: **GitHub Actions**
- Organization or user: `kibae`
- Repository: `node-circuit-breaker`
- Workflow filename: `npm-publish.yml`
- Environment (optional): must exactly match `github action` if set

## Notes
- OIDC publishing also generates npm **provenance** automatically.
- After verifying a successful release, the `NPM_TOKEN` secret can be deleted.
- GitHub Releases are now created manually (no longer automated by this workflow).